### PR TITLE
[minseok-oh] step-6 기물 이동 구현

### DIFF
--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -2,8 +2,6 @@ package chess;
 
 import chess.pieces.*;
 
-import static chess.utils.StringUtils.appendNewLine;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -13,145 +11,47 @@ public class Board {
     private final List<Rank> board = new ArrayList<>();
     public static final int BOARD_SIZE = 8;
 
-    public int pieceCount() {
-        int count = 0;
-        for (int i = 0; i < BOARD_SIZE; i++) {
-            count += board.get(i).getCount();
-        }
-        return count;
-    }
-
-    public void initializeEmpty() {
+    public void initialize() {
         for (int i = 0; i < BOARD_SIZE; i++) {
             List<Piece> pieceList = new ArrayList<>();
             for (int j = 0; j < BOARD_SIZE; j++) {
-                pieceList.add(Piece.createBlank());
+                pieceList.add(Piece.createBlank(new Position(j, i)));
             }
             board.add(new Rank(pieceList));
         }
     }
 
-    private void initializeWhitePiece() {
-        List<Piece> pieceList = new ArrayList<>();
-        pieceList.add(Piece.createWhiteRook());
-        pieceList.add(Piece.createWhiteKnight());
-        pieceList.add(Piece.createWhiteBishop());
-        pieceList.add(Piece.createWhiteQueen());
-        pieceList.add(Piece.createWhiteKing());
-        pieceList.add(Piece.createWhiteBishop());
-        pieceList.add(Piece.createWhiteKnight());
-        pieceList.add(Piece.createWhiteRook());
-        board.set(7, new Rank(pieceList));
+    public List<Rank> findAll() { return this.board; }
 
-        List<Piece> pawnList = new ArrayList<>();
-        for (int i = 0; i < BOARD_SIZE; i++) {
-            Piece piece = Piece.createWhitePawn();
-            pawnList.add(piece);
-        }
-        board.set(6, new Rank(pawnList));
-    }
-
-    private void initializeBlackPiece() {
-        List<Piece> pieceList = new ArrayList<>();
-        pieceList.add(Piece.createBlackRook());
-        pieceList.add(Piece.createBlackKnight());
-        pieceList.add(Piece.createBlackBishop());
-        pieceList.add(Piece.createBlackQueen());
-        pieceList.add(Piece.createBlackKing());
-        pieceList.add(Piece.createBlackBishop());
-        pieceList.add(Piece.createBlackKnight());
-        pieceList.add(Piece.createBlackRook());
-        board.set(0, new Rank(pieceList));
-
-        List<Piece> pawnList = new ArrayList<>();
-        for (int i = 0; i < BOARD_SIZE; i++) {
-            Piece piece = Piece.createBlackPawn();
-            pawnList.add(piece);
-        }
-        board.set(1, new Rank(pawnList));
-    }
-
-    public void initialize() {
-        initializeEmpty();
-        initializeWhitePiece();
-        initializeBlackPiece();
-    }
-
-    public String showBoard() {
-        StringBuilder printResult = new StringBuilder();
-        for (int i = 0; i < BOARD_SIZE; i++) {
-            String line = appendNewLine(board.get(i).showRank());
-            printResult.append(line);
-        }
-        return printResult.toString();
-    }
-
-    public int countPieces(final Color color, final Type type) {
-        int count = 0;
-        for (int i = 0; i < BOARD_SIZE; i++) {
-            count += board.get(i).getCount(color, type);
-        }
-        return count;
-    }
-
-    public Piece findPiece(final String position) {
-        Position piecePosition = new Position(position);
-        return board.get(piecePosition.getY()).get(piecePosition.getX());
-    }
-
-    public void move(final String position, final Piece piece) {
-        Position piecePosition = new Position(position);
-        board.get(piecePosition.getY()).move(piecePosition.getX(), piece);
-    }
-
-    private double calculatePawns(int[] pawns) {
-        double result = 0;
-        for (int i = 0; i < BOARD_SIZE; i++) {
-            if (pawns[i] == 1) result += 1;
-            else result += 0.5 * pawns[i];
-        }
-        return result;
-    }
-
-    public double calculatePoint(final Color color) {
-        double point = 0;
-        int[] pawns = new int[BOARD_SIZE];
-
-        for (int i = 0; i < BOARD_SIZE; i++) {
-            Rank rank = board.get(i);
-            for (int j = 0; j < BOARD_SIZE; j++) {
-                Piece piece = rank.get(j);
-                if (!Objects.equals(piece.getColor(), color)) continue;
-
-                if (Objects.equals(piece.getType(), Type.PAWN)) pawns[j] += 1;
-                else point += piece.getType().getDefaultPoint();
-            }
-        }
-        point += calculatePawns(pawns);
-        return point;
-    }
-
-    public List<Piece> getSortedPieces(final Color color) {
+    public List<Piece> findByColor(final Color color) {
         List<Piece> pieces = new ArrayList<>();
         for (int i = 0; i < BOARD_SIZE; i++) {
             Rank rank = board.get(i);
             for (int j = 0; j < BOARD_SIZE; j++) {
                 Piece piece = rank.get(j);
-                if (Objects.equals(piece.getColor(), color)) pieces.add(piece);
+                if (Objects.equals(color, piece.getColor())) pieces.add(piece);
             }
         }
-        Collections.sort(pieces);
         return pieces;
     }
 
-    // test를 위한 메서드
-    public void updateBoard(final List<String> exampleBoard) {
-        for (int i = 0; i < Board.BOARD_SIZE; i++) {
-            List<Piece> pieces = new ArrayList<>();
-            for (int j = 0; j < Board.BOARD_SIZE; j++) {
-                pieces.add(Piece.create(exampleBoard.get(i).charAt(j)));
-            }
-            board.set(i, new Rank(pieces));
-        }
+    public Piece findPiece(final String stringPosition) {
+        Position position = new Position(stringPosition);
+        return board.get(position.getY()).get(position.getX());
+    }
+    public Piece findByPosition(final Position position) {
+        return board.get(position.getY()).get(position.getX());
+    }
+
+    public void saveByPosition(final Piece piece, final Position position) {
+        Rank rank = board.get(position.getY());
+        Rank newRank = rank.move(position.getX(), piece, position);
+        board.set(position.getY(), newRank);
+    }
+
+    public List<Piece> getSortedPieces(final Color color) {
+        List<Piece> pieces = findByColor(color);
+        Collections.sort(pieces);
+        return pieces;
     }
 }

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -1,5 +1,6 @@
 package chess;
 
+import chess.constant.Color;
 import chess.pieces.*;
 
 import java.util.ArrayList;

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -16,7 +16,7 @@ public class Board {
         for (int i = 0; i < BOARD_SIZE; i++) {
             List<Piece> pieceList = new ArrayList<>();
             for (int j = 0; j < BOARD_SIZE; j++) {
-                pieceList.add(Piece.createBlank(new Position(j, i)));
+                pieceList.add(PieceFactory.createBlank(new Position(j, i)));
             }
             board.add(new Rank(pieceList));
         }

--- a/src/main/java/chess/ChessGame.java
+++ b/src/main/java/chess/ChessGame.java
@@ -1,6 +1,7 @@
 package chess;
 
 import chess.constant.Color;
+import chess.constant.Direction;
 import chess.constant.Type;
 import chess.pieces.*;
 
@@ -33,32 +34,32 @@ public class ChessGame {
     }
 
     private void initializeWhitePiece() {
-        board.saveByPosition(Piece.createWhiteRook(null), new Position("a1"));
-        board.saveByPosition(Piece.createWhiteKnight(null), new Position("b1"));
-        board.saveByPosition(Piece.createWhiteBishop(null), new Position("c1"));
-        board.saveByPosition(Piece.createWhiteQueen(null), new Position("d1"));
-        board.saveByPosition(Piece.createWhiteKing(null), new Position("e1"));
-        board.saveByPosition(Piece.createWhiteBishop(null), new Position("f1"));
-        board.saveByPosition(Piece.createWhiteKnight(null), new Position("g1"));
-        board.saveByPosition(Piece.createWhiteRook(null), new Position("h1"));
+        board.saveByPosition(PieceFactory.createRook(Color.WHITE, null), new Position("a1"));
+        board.saveByPosition(PieceFactory.createKnight(Color.WHITE, null), new Position("b1"));
+        board.saveByPosition(PieceFactory.createBishop(Color.WHITE, null), new Position("c1"));
+        board.saveByPosition(PieceFactory.createQueen(Color.WHITE, null), new Position("d1"));
+        board.saveByPosition(PieceFactory.createKing(Color.WHITE, null), new Position("e1"));
+        board.saveByPosition(PieceFactory.createBishop(Color.WHITE, null), new Position("f1"));
+        board.saveByPosition(PieceFactory.createKnight(Color.WHITE, null), new Position("g1"));
+        board.saveByPosition(PieceFactory.createRook(Color.WHITE, null), new Position("h1"));
 
         for (int i = 0; i < BOARD_SIZE; i++) {
-            board.saveByPosition(Piece.createWhitePawn(null), new Position(i, 6));
+            board.saveByPosition(PieceFactory.createPawn(Color.WHITE, null), new Position(i, 6));
         }
     }
 
     private void initializeBlackPiece() {
-        board.saveByPosition(Piece.createBlackRook(null), new Position("a8"));
-        board.saveByPosition(Piece.createBlackKnight(null), new Position("b8"));
-        board.saveByPosition(Piece.createBlackBishop(null), new Position("c8"));
-        board.saveByPosition(Piece.createBlackQueen(null), new Position("d8"));
-        board.saveByPosition(Piece.createBlackKing(null), new Position("e8"));
-        board.saveByPosition(Piece.createBlackBishop(null), new Position("f8"));
-        board.saveByPosition(Piece.createBlackKnight(null), new Position("g8"));
-        board.saveByPosition(Piece.createBlackRook(null), new Position("h8"));
+        board.saveByPosition(PieceFactory.createRook(Color.BLACK, null), new Position("a8"));
+        board.saveByPosition(PieceFactory.createKnight(Color.BLACK, null), new Position("b8"));
+        board.saveByPosition(PieceFactory.createBishop(Color.BLACK, null), new Position("c8"));
+        board.saveByPosition(PieceFactory.createQueen(Color.BLACK, null), new Position("d8"));
+        board.saveByPosition(PieceFactory.createKing(Color.BLACK, null), new Position("e8"));
+        board.saveByPosition(PieceFactory.createBishop(Color.BLACK, null), new Position("f8"));
+        board.saveByPosition(PieceFactory.createKnight(Color.BLACK, null), new Position("g8"));
+        board.saveByPosition(PieceFactory.createRook(Color.BLACK, null), new Position("h8"));
 
         for (int i = 0; i < BOARD_SIZE; i++) {
-            board.saveByPosition(Piece.createBlackPawn(null), new Position(i, 1));
+            board.saveByPosition(PieceFactory.createPawn(Color.BLACK, null), new Position(i, 1));
         }
     }
 
@@ -100,11 +101,16 @@ public class ChessGame {
 
         Piece piece = board.findByPosition(sourcePosition);
         if (destinationPosition.isOutOfIndex()) return;
+
+        Piece destinationPiece = board.findByPosition(destinationPosition);
         if (isColorSame(piece.getColor(), destinationPosition)) return;
-        if (!isMoveAvailable(piece, destinationPosition)) return;
+        if (!piece.verifyMovePosition(destinationPiece)) return;
+
+        Direction direction = piece.getDirection(destinationPosition);
+        if (!verifyMoveDirection(direction, sourcePosition, destinationPosition)) return;
 
         board.saveByPosition(piece, destinationPosition);
-        board.saveByPosition(Piece.createBlank(sourcePosition), sourcePosition);
+        board.saveByPosition(PieceFactory.createBlank(sourcePosition), sourcePosition);
     }
 
     private boolean isColorSame(final Color color, final Position position) {
@@ -112,50 +118,14 @@ public class ChessGame {
         return Objects.equals(color, piece.getColor());
     }
 
-    private boolean isMoveAvailable(final Piece piece, final Position position) {
-        if (Objects.equals(piece.getType(), Type.KING)) {
-            return isKingMoveAvailable(piece, position);
+    private boolean verifyMoveDirection(final Direction direction, final Position source, final Position destination) {
+        Position position = new Position(source.getX() + direction.getXDegree(), source.getY() + direction.getYDegree());
+        while (!Objects.equals(position, destination)) {
+            Piece piece = board.findByPosition(position);
+            if (!Objects.equals(piece.getType(), Type.NO_PIECE)) return false;
+
+            position = new Position(position.getX() + direction.getXDegree(), position.getY() + direction.getYDegree());
         }
-        if (Objects.equals(piece.getType(), Type.QUEEN)) {
-            return isQueenMoveAvailable(piece, position);
-        }
-        return false;
-    }
-
-    private boolean isKingMoveAvailable(final Piece piece, final Position position) {
-        Position sourcePosition = piece.getPosition();
-        final int[] y_grad = {-1, -1, -1, 0, 0, 1, 1, 1};
-        final int[] x_grad = {-1, 0, 1, -1, 1, -1, 0, 1};
-
-        for (int i = 0; i < 8; i++) {
-            int y = sourcePosition.getY() + y_grad[i];
-            int x = sourcePosition.getX() + x_grad[i];
-            if (position.getX() == x && position.getY() == y) return true;
-        }
-        return false;
-    }
-
-    private boolean isQueenMoveAvailable(final Piece piece, final Position position) {
-        Position sourcePosition = piece.getPosition();
-        final int[] y_grad = {-1, -1, -1, 0, 0, 1, 1, 1};
-        final int[] x_grad = {-1, 0, 1, -1, 1, -1, 0, 1};
-
-        for (int i = 0; i < 8; i++) {
-            Position nextPosition = new Position(sourcePosition.getX() + x_grad[i], sourcePosition.getY() + y_grad[i]);
-            boolean moveAvailable = moveVirtualQueen(nextPosition, position, y_grad[i], x_grad[i]);
-            if (moveAvailable) return true;
-        }
-        return false;
-    }
-
-    private boolean moveVirtualQueen(final Position source, final Position destination, final int y_grad, final int x_grad) {
-        if (source.isOutOfIndex()) return false;
-        if (source.getX() == destination.getX() && source.getY() == destination.getY()) return true;
-
-        Piece piece = board.findByPosition(source);
-        if (!Objects.equals(piece.getType(), Type.NO_PIECE)) return false;
-
-        Position position = new Position(source.getX() + x_grad, source.getY() + y_grad);
-        return moveVirtualQueen(position, destination, y_grad, x_grad);
+        return true;
     }
 }

--- a/src/main/java/chess/ChessGame.java
+++ b/src/main/java/chess/ChessGame.java
@@ -1,5 +1,7 @@
 package chess;
 
+import chess.constant.Color;
+import chess.constant.Type;
 import chess.pieces.*;
 
 import java.util.List;
@@ -114,13 +116,16 @@ public class ChessGame {
         if (Objects.equals(piece.getType(), Type.KING)) {
             return isKingMoveAvailable(piece, position);
         }
+        if (Objects.equals(piece.getType(), Type.QUEEN)) {
+            return isQueenMoveAvailable(piece, position);
+        }
         return false;
     }
 
     private boolean isKingMoveAvailable(final Piece piece, final Position position) {
         Position sourcePosition = piece.getPosition();
-        final int[] y_grad = {-1, -1, -1, 0, 0, 0, 1, 1, 1};
-        final int[] x_grad = {-1, 0, 1, -1, 0, 1, -1, 0, 1};
+        final int[] y_grad = {-1, -1, -1, 0, 0, 1, 1, 1};
+        final int[] x_grad = {-1, 0, 1, -1, 1, -1, 0, 1};
 
         for (int i = 0; i < 8; i++) {
             int y = sourcePosition.getY() + y_grad[i];
@@ -128,5 +133,29 @@ public class ChessGame {
             if (position.getX() == x && position.getY() == y) return true;
         }
         return false;
+    }
+
+    private boolean isQueenMoveAvailable(final Piece piece, final Position position) {
+        Position sourcePosition = piece.getPosition();
+        final int[] y_grad = {-1, -1, -1, 0, 0, 1, 1, 1};
+        final int[] x_grad = {-1, 0, 1, -1, 1, -1, 0, 1};
+
+        for (int i = 0; i < 8; i++) {
+            Position nextPosition = new Position(sourcePosition.getX() + x_grad[i], sourcePosition.getY() + y_grad[i]);
+            boolean moveAvailable = moveVirtualQueen(nextPosition, position, y_grad[i], x_grad[i]);
+            if (moveAvailable) return true;
+        }
+        return false;
+    }
+
+    private boolean moveVirtualQueen(final Position source, final Position destination, final int y_grad, final int x_grad) {
+        if (source.isOutOfIndex()) return false;
+        if (source.getX() == destination.getX() && source.getY() == destination.getY()) return true;
+
+        Piece piece = board.findByPosition(source);
+        if (!Objects.equals(piece.getType(), Type.NO_PIECE)) return false;
+
+        Position position = new Position(source.getX() + x_grad, source.getY() + y_grad);
+        return moveVirtualQueen(position, destination, y_grad, x_grad);
     }
 }

--- a/src/main/java/chess/ChessGame.java
+++ b/src/main/java/chess/ChessGame.java
@@ -95,9 +95,38 @@ public class ChessGame {
     public void move(final String source, final String destination) {
         Position sourcePosition = new Position(source);
         Position destinationPosition = new Position(destination);
+
         Piece piece = board.findByPosition(sourcePosition);
+        if (destinationPosition.isOutOfIndex()) return;
+        if (isColorSame(piece.getColor(), destinationPosition)) return;
+        if (!isMoveAvailable(piece, destinationPosition)) return;
 
         board.saveByPosition(piece, destinationPosition);
         board.saveByPosition(Piece.createBlank(sourcePosition), sourcePosition);
+    }
+
+    private boolean isColorSame(final Color color, final Position position) {
+        Piece piece = board.findByPosition(position);
+        return Objects.equals(color, piece.getColor());
+    }
+
+    private boolean isMoveAvailable(final Piece piece, final Position position) {
+        if (Objects.equals(piece.getType(), Type.KING)) {
+            return isKingMoveAvailable(piece, position);
+        }
+        return false;
+    }
+
+    private boolean isKingMoveAvailable(final Piece piece, final Position position) {
+        Position sourcePosition = piece.getPosition();
+        final int[] y_grad = {-1, -1, -1, 0, 0, 0, 1, 1, 1};
+        final int[] x_grad = {-1, 0, 1, -1, 0, 1, -1, 0, 1};
+
+        for (int i = 0; i < 8; i++) {
+            int y = sourcePosition.getY() + y_grad[i];
+            int x = sourcePosition.getX() + x_grad[i];
+            if (position.getX() == x && position.getY() == y) return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/chess/ChessGame.java
+++ b/src/main/java/chess/ChessGame.java
@@ -1,0 +1,103 @@
+package chess;
+
+import chess.pieces.*;
+
+import java.util.List;
+import java.util.Objects;
+
+import static chess.Board.BOARD_SIZE;
+
+public class ChessGame {
+    private final Board board;
+
+    public ChessGame(Board board) {
+        this.board = board;
+    }
+
+    public int pieceCount() {
+        List<Rank> ranks = board.findAll();
+
+        int count = 0;
+        for (int i = 0; i < BOARD_SIZE; i++) {
+            count += ranks.get(i).getCount();
+        }
+        return count;
+    }
+
+    public void start() {
+        board.initialize();
+        initializeWhitePiece();
+        initializeBlackPiece();
+    }
+
+    private void initializeWhitePiece() {
+        board.saveByPosition(Piece.createWhiteRook(null), new Position("a1"));
+        board.saveByPosition(Piece.createWhiteKnight(null), new Position("b1"));
+        board.saveByPosition(Piece.createWhiteBishop(null), new Position("c1"));
+        board.saveByPosition(Piece.createWhiteQueen(null), new Position("d1"));
+        board.saveByPosition(Piece.createWhiteKing(null), new Position("e1"));
+        board.saveByPosition(Piece.createWhiteBishop(null), new Position("f1"));
+        board.saveByPosition(Piece.createWhiteKnight(null), new Position("g1"));
+        board.saveByPosition(Piece.createWhiteRook(null), new Position("h1"));
+
+        for (int i = 0; i < BOARD_SIZE; i++) {
+            board.saveByPosition(Piece.createWhitePawn(null), new Position(i, 6));
+        }
+    }
+
+    private void initializeBlackPiece() {
+        board.saveByPosition(Piece.createBlackRook(null), new Position("a8"));
+        board.saveByPosition(Piece.createBlackKnight(null), new Position("b8"));
+        board.saveByPosition(Piece.createBlackBishop(null), new Position("c8"));
+        board.saveByPosition(Piece.createBlackQueen(null), new Position("d8"));
+        board.saveByPosition(Piece.createBlackKing(null), new Position("e8"));
+        board.saveByPosition(Piece.createBlackBishop(null), new Position("f8"));
+        board.saveByPosition(Piece.createBlackKnight(null), new Position("g8"));
+        board.saveByPosition(Piece.createBlackRook(null), new Position("h8"));
+
+        for (int i = 0; i < BOARD_SIZE; i++) {
+            board.saveByPosition(Piece.createBlackPawn(null), new Position(i, 1));
+        }
+    }
+
+    public int countPieces(final Color color, final Type type) {
+        List<Piece> pieces = board.findByColor(color);
+        return (int) pieces.stream().filter(piece -> Objects.equals(type, piece.getType())).count();
+    }
+
+    private double calculatePawns(int[] pawns) {
+        double point = 0;
+        for (int i = 0; i < BOARD_SIZE; i++) {
+            if (pawns[i] == 1) point += Type.PAWN.getDefaultPoint();
+            else point += (Type.PAWN.getDefaultPoint() / 2) * pawns[i];
+        }
+        return point;
+    }
+
+    public double calculatePoint(final Color color) {
+        double point = 0;
+        int[] pawns = new int[BOARD_SIZE];
+        List<Piece> pieces = board.findByColor(color);
+
+        for (Piece piece : pieces) {
+            if (!Objects.equals(piece.getType(), Type.PAWN)) point += piece.getType().getDefaultPoint();
+            else pawns[piece.getPosition().getX()] += 1;
+        }
+        point += calculatePawns(pawns);
+        return point;
+    }
+
+    public void move(final String position, final Piece piece) {
+        Position piecePosition = new Position(position);
+        board.saveByPosition(piece, piecePosition);
+    }
+
+    public void move(final String source, final String destination) {
+        Position sourcePosition = new Position(source);
+        Position destinationPosition = new Position(destination);
+        Piece piece = board.findByPosition(sourcePosition);
+
+        board.saveByPosition(piece, destinationPosition);
+        board.saveByPosition(Piece.createBlank(sourcePosition), sourcePosition);
+    }
+}

--- a/src/main/java/chess/ChessView.java
+++ b/src/main/java/chess/ChessView.java
@@ -1,7 +1,5 @@
 package chess;
 
-import chess.pieces.Rank;
-
 import java.util.List;
 
 import static chess.Board.BOARD_SIZE;

--- a/src/main/java/chess/ChessView.java
+++ b/src/main/java/chess/ChessView.java
@@ -1,0 +1,26 @@
+package chess;
+
+import chess.pieces.Rank;
+
+import java.util.List;
+
+import static chess.Board.BOARD_SIZE;
+import static chess.utils.StringUtils.appendNewLine;
+
+public class ChessView {
+    private final Board board;
+
+    public ChessView(Board board) {
+        this.board = board;
+    }
+
+    public String showBoard() {
+        List<Rank> ranks = board.findAll();
+        StringBuilder printResult = new StringBuilder();
+        for (int i = 0; i < BOARD_SIZE; i++) {
+            String line = appendNewLine(ranks.get(i).showRank());
+            printResult.append(line);
+        }
+        return printResult.toString();
+    }
+}

--- a/src/main/java/chess/Main.java
+++ b/src/main/java/chess/Main.java
@@ -5,14 +5,20 @@ import java.util.Scanner;
 public class Main {
     private static final Scanner scanner = new Scanner(System.in);
     private static final Board board = new Board();
+    private static final ChessGame chessGame = new ChessGame(board);
+    private static final ChessView chessView = new ChessView(board);
 
     public static void main(String[] args) {
-        board.initialize();
-
+        chessGame.start();
         while(true) {
-            String operator = scanner.next();
-            if (operator.equals("start")) System.out.println(board.showBoard());
+            String operator = scanner.nextLine();
+            if (operator.equals("start")) System.out.println(chessView.showBoard());
             if (operator.equals("end")) return;
+            if (operator.startsWith("move")) {
+                String[] operands = operator.split(" ");
+                chessGame.move(operands[1], operands[2]);
+                System.out.println(chessView.showBoard());
+            }
         }
     }
 }

--- a/src/main/java/chess/Position.java
+++ b/src/main/java/chess/Position.java
@@ -15,10 +15,10 @@ public class Position {
     @Override
     public boolean equals(Object o) {
         if (Objects.equals(o, null)) return false;
+        if (getClass() != o.getClass()) return false;
 
         Position position = (Position) o;
-        if (this.getX() == position.getX() && this.getY() == position.getY()) return true;
-        else return false;
+        return this.getX() == position.getX() && this.getY() == position.getY();
     }
 
     public Position(final String position) {

--- a/src/main/java/chess/Position.java
+++ b/src/main/java/chess/Position.java
@@ -18,7 +18,7 @@ public class Position {
 
         Position position = (Position) o;
         if (this.getX() == position.getX() && this.getY() == position.getY()) return true;
-        else return true;
+        else return false;
     }
 
     public Position(final String position) {

--- a/src/main/java/chess/Position.java
+++ b/src/main/java/chess/Position.java
@@ -1,5 +1,7 @@
 package chess;
 
+import java.util.Objects;
+
 import static chess.Board.BOARD_SIZE;
 
 public class Position {
@@ -8,6 +10,15 @@ public class Position {
     public Position(final int x, final int y) {
         this.x = x;
         this.y = y;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (Objects.equals(o, null)) return false;
+
+        Position position = (Position) o;
+        if (this.getX() == position.getX() && this.getY() == position.getY()) return true;
+        else return true;
     }
 
     public Position(final String position) {

--- a/src/main/java/chess/Position.java
+++ b/src/main/java/chess/Position.java
@@ -1,4 +1,4 @@
-package chess.pieces;
+package chess;
 
 import static chess.Board.BOARD_SIZE;
 

--- a/src/main/java/chess/Rank.java
+++ b/src/main/java/chess/Rank.java
@@ -2,6 +2,7 @@ package chess;
 
 import chess.constant.Type;
 import chess.pieces.Piece;
+import chess.pieces.PieceFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +33,7 @@ public class Rank {
 
     public Rank move(final int x, final Piece piece, final Position position) {
         List<Piece> newRank = new ArrayList<>(rank);
-        newRank.set(x, Piece.createMovedPiece(piece, position));
+        newRank.set(x, PieceFactory.createMovedPiece(piece, position));
         return new Rank(newRank);
     }
 }

--- a/src/main/java/chess/Rank.java
+++ b/src/main/java/chess/Rank.java
@@ -1,4 +1,7 @@
-package chess.pieces;
+package chess;
+
+import chess.constant.Type;
+import chess.pieces.Piece;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/chess/constant/Color.java
+++ b/src/main/java/chess/constant/Color.java
@@ -1,4 +1,4 @@
-package chess.pieces;
+package chess.constant;
 
 public enum Color {
     WHITE, BLACK, NO_COLOR

--- a/src/main/java/chess/constant/Direction.java
+++ b/src/main/java/chess/constant/Direction.java
@@ -1,0 +1,65 @@
+package chess.constant;
+
+import java.util.Arrays;
+import java.util.List;
+
+public enum Direction {
+    NORTH(0, 1),
+    NORTHEAST(1, 1),
+    EAST(1, 0),
+    SOUTHEAST(1, -1),
+    SOUTH(0, -1),
+    SOUTHWEST(-1, -1),
+    WEST(-1, 0),
+    NORTHWEST(-1, 1),
+
+    NNE(1, 2),
+    NNW(-1, 2),
+    SSE(1, -2),
+    SSW(-1, -2),
+    EEN(2, 1),
+    EES(2, -1),
+    WWN(-2, 1),
+    WWS(-2, -1);
+
+    private int xDegree;
+    private int yDegree;
+
+    private Direction(int xDegree, int yDegree) {
+        this.xDegree = xDegree;
+        this.yDegree = yDegree;
+    }
+
+    public int getXDegree() {
+        return xDegree;
+    }
+
+    public int getYDegree() {
+        return yDegree;
+    }
+
+    public static List<Direction> linearDirection() {
+        return Arrays.asList(NORTH, EAST, SOUTH, WEST);
+    }
+
+    public static List<Direction> diagonalDirection() {
+        return Arrays.asList(NORTHEAST, SOUTHEAST, SOUTHWEST, NORTHWEST);
+    }
+
+    public static List<Direction> everyDirection() {
+        return Arrays.asList(NORTH, EAST, SOUTH, WEST, NORTHEAST, SOUTHEAST, SOUTHWEST, NORTHWEST);
+    }
+
+    public static List<Direction> knightDirection() {
+        return Arrays.asList(NNE, NNW, SSE, SSW, EEN, EES, WWN, WWS);
+    }
+
+    public static List<Direction> whitePawnDirection() {
+        return Arrays.asList(NORTH, NORTHEAST, NORTHWEST);
+    }
+
+    public static List<Direction> blackPawnDirection() {
+        return Arrays.asList(SOUTH, SOUTHEAST, SOUTHWEST);
+    }
+}
+

--- a/src/main/java/chess/constant/Direction.java
+++ b/src/main/java/chess/constant/Direction.java
@@ -20,7 +20,10 @@ public enum Direction {
     EEN(2, 1),
     EES(2, -1),
     WWN(-2, 1),
-    WWS(-2, -1);
+    WWS(-2, -1),
+
+    NORTH_TWICE(0, 2),
+    SOUTH_TWICE(0, -2);
 
     private int xDegree;
     private int yDegree;
@@ -55,11 +58,11 @@ public enum Direction {
     }
 
     public static List<Direction> whitePawnDirection() {
-        return Arrays.asList(NORTH, NORTHEAST, NORTHWEST);
+        return Arrays.asList(SOUTH, SOUTHEAST, SOUTHWEST);
     }
 
     public static List<Direction> blackPawnDirection() {
-        return Arrays.asList(SOUTH, SOUTHEAST, SOUTHWEST);
+        return Arrays.asList(NORTH, NORTHEAST, NORTHWEST);
     }
 }
 

--- a/src/main/java/chess/constant/Direction.java
+++ b/src/main/java/chess/constant/Direction.java
@@ -25,10 +25,10 @@ public enum Direction {
     NORTH_TWICE(0, 2),
     SOUTH_TWICE(0, -2);
 
-    private int xDegree;
-    private int yDegree;
+    private final int xDegree;
+    private final int yDegree;
 
-    private Direction(int xDegree, int yDegree) {
+    Direction(int xDegree, int yDegree) {
         this.xDegree = xDegree;
         this.yDegree = yDegree;
     }

--- a/src/main/java/chess/constant/Type.java
+++ b/src/main/java/chess/constant/Type.java
@@ -1,4 +1,4 @@
-package chess.pieces;
+package chess.constant;
 
 public enum Type {
     PAWN('p', 1.0),

--- a/src/main/java/chess/pieces/Bishop.java
+++ b/src/main/java/chess/pieces/Bishop.java
@@ -1,0 +1,44 @@
+package chess.pieces;
+
+import chess.Position;
+import chess.constant.Color;
+import chess.constant.Direction;
+import chess.constant.Type;
+
+import java.util.List;
+
+public class Bishop extends Piece {
+    private final List<Direction> directions = Direction.diagonalDirection();
+
+    private Bishop(final Color color, final Position position) { super(color, Type.BISHOP, position); }
+
+    public static Piece create(Color color, Position position) {
+        return new Bishop(color, position);
+    }
+
+    @Override
+    public boolean verifyMovePosition(final Piece piece) {
+        Position sourcePosition = this.getPosition();
+        Position destinationPosition = piece.getPosition();
+
+        for (Direction direction: directions) {
+            Position nextPosition = new Position(sourcePosition.getX() + direction.getXDegree(), sourcePosition.getY() + direction.getYDegree());
+            boolean moveAvailable = moveVirtualBishop(nextPosition, destinationPosition, direction.getYDegree(), direction.getXDegree());
+            if (moveAvailable) return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Direction getDirection(Position position) {
+        return getDirection(position, directions);
+    }
+
+    private boolean moveVirtualBishop(final Position source, final Position destination, final int y_grad, final int x_grad) {
+        if (source.isOutOfIndex()) return false;
+        if (source.getX() == destination.getX() && source.getY() == destination.getY()) return true;
+
+        Position position = new Position(source.getX() + x_grad, source.getY() + y_grad);
+        return moveVirtualBishop(position, destination, y_grad, x_grad);
+    }
+}

--- a/src/main/java/chess/pieces/Blank.java
+++ b/src/main/java/chess/pieces/Blank.java
@@ -1,0 +1,26 @@
+package chess.pieces;
+
+import chess.Position;
+import chess.constant.Color;
+import chess.constant.Direction;
+import chess.constant.Type;
+
+public class Blank extends Piece {
+    protected Blank(Position position) {
+        super(Color.NO_COLOR, Type.NO_PIECE, position);
+    }
+
+    public static Piece create(Position position) {
+        return new Blank(position);
+    }
+
+    @Override
+    public boolean verifyMovePosition(final Piece piece) {
+        return false;
+    }
+
+    @Override
+    public Direction getDirection(Position position) {
+        return null;
+    }
+}

--- a/src/main/java/chess/pieces/King.java
+++ b/src/main/java/chess/pieces/King.java
@@ -1,0 +1,35 @@
+package chess.pieces;
+
+import chess.Position;
+import chess.constant.Color;
+import chess.constant.Direction;
+import chess.constant.Type;
+
+import java.util.List;
+
+public class King extends Piece {
+    private final List<Direction> directions = Direction.everyDirection();
+    private King(final Color color, final Position position) { super(color, Type.KING, position); }
+
+    public static Piece create(Color color, Position position) {
+        return new King(color, position);
+    }
+
+    @Override
+    public boolean verifyMovePosition(final Piece piece) {
+        Position sourcePosition = this.getPosition();
+        Position destinationPosition = piece.getPosition();
+
+        for (Direction direction: directions) {
+            int y = sourcePosition.getY() + direction.getYDegree();
+            int x = sourcePosition.getX() + direction.getXDegree();
+            if (destinationPosition.getX() == x && destinationPosition.getY() == y) return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Direction getDirection(Position position) {
+        return getDirection(position, directions);
+    }
+}

--- a/src/main/java/chess/pieces/Knight.java
+++ b/src/main/java/chess/pieces/Knight.java
@@ -1,0 +1,38 @@
+package chess.pieces;
+
+import chess.Position;
+import chess.constant.Color;
+import chess.constant.Direction;
+import chess.constant.Type;
+
+import java.util.List;
+
+public class Knight extends Piece {
+    private final List<Direction> directions = Direction.knightDirection();
+    private Knight(final Color color, final Position position) {
+        super(color, Type.KNIGHT, position);
+    }
+
+    public static Piece create(Color color, Position position) {
+        return new Knight(color, position);
+    }
+
+    @Override
+    public boolean verifyMovePosition(final Piece piece) {
+        Position sourcePosition = this.getPosition();
+        Position destinationPosition = piece.getPosition();
+
+        for (Direction direction: directions) {
+            int y = sourcePosition.getY() + direction.getYDegree();
+            int x = sourcePosition.getX() + direction.getXDegree();
+            if (destinationPosition.getX() == x && destinationPosition.getY() == y) return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Direction getDirection(Position position) {
+        return getDirection(position, directions);
+    }
+
+}

--- a/src/main/java/chess/pieces/Pawn.java
+++ b/src/main/java/chess/pieces/Pawn.java
@@ -1,0 +1,57 @@
+package chess.pieces;
+
+import chess.Position;
+import chess.constant.Color;
+import chess.constant.Direction;
+import chess.constant.Type;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class Pawn extends Piece {
+    private final List<Direction> directions;
+
+    private Pawn(final Color color, final Position position) {
+        super(color, Type.PAWN, position);
+        if (isBlack()) directions = Direction.blackPawnDirection();
+        else directions = Direction.whitePawnDirection();
+    }
+
+    public static Piece create(Color color, Position position) {
+        return new Pawn(color, position);
+    }
+
+    @Override
+    public boolean verifyMovePosition(final Piece piece) {
+        List<Direction> currentDirections = new ArrayList<>(directions);
+        if (this.getPosition().getY() == 1 && this.isBlack()) currentDirections.add(Direction.NORTH_TWICE);
+        if (this.getPosition().getY() == 7 && this.isWhite()) currentDirections.add(Direction.SOUTH_TWICE);
+
+        // Pawn이 이동할 수 있는 장소에 있는가?
+        boolean canMovePosition = false;
+        Position sourcePosition = this.getPosition();
+        Position destinationPosition = piece.getPosition();
+        for (Direction direction: currentDirections) {
+            int y = sourcePosition.getY() + direction.getYDegree();
+            int x = sourcePosition.getX() + direction.getXDegree();
+            if (destinationPosition.getX() == x && destinationPosition.getY() == y) canMovePosition = true;
+        }
+        if (!canMovePosition) return false;
+
+        // Pawn이 앞으로 이동하면 목적지에 빈칸이 대각선으로 이동하면 다른 기물이 있는가?
+        Direction direction = getDirection(piece.getPosition());
+        if (direction == Direction.SOUTH || direction == Direction.NORTH) {
+            return Objects.equals(piece.getType(), Type.NO_PIECE);
+        }
+        else {
+            return !Objects.equals(piece.getType(), Type.NO_PIECE);
+        }
+    }
+
+    @Override
+    public Direction getDirection(Position position) {
+        return getDirection(position, directions);
+    }
+
+}

--- a/src/main/java/chess/pieces/Pawn.java
+++ b/src/main/java/chess/pieces/Pawn.java
@@ -35,7 +35,7 @@ public class Pawn extends Piece {
         for (Direction direction: currentDirections) {
             int y = sourcePosition.getY() + direction.getYDegree();
             int x = sourcePosition.getX() + direction.getXDegree();
-            if (destinationPosition.getX() == x && destinationPosition.getY() == y) canMovePosition = true;
+            canMovePosition |= (destinationPosition.getX() == x && destinationPosition.getY() == y);
         }
         if (!canMovePosition) return false;
 

--- a/src/main/java/chess/pieces/Piece.java
+++ b/src/main/java/chess/pieces/Piece.java
@@ -2,7 +2,28 @@ package chess.pieces;
 
 import java.util.Objects;
 
-public record Piece (Color color, Type type) implements Comparable<Piece> {
+public class Piece implements Comparable<Piece> {
+
+    private final Color color;
+    private final Type type;
+    private final Position position;
+
+    private Piece(final Color color, final Type type, final Position position) {
+        this.color = color;
+        this.type = type;
+        this.position = position;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (Objects.equals(o, null)) return false;
+
+        Piece piece = (Piece) o;
+        if (!Objects.equals(this.color, piece.getColor())) return false;
+        if (!Objects.equals(this.type, piece.getType())) return false;
+
+        return true;
+    }
 
     public Color getColor() {
         return this.color;
@@ -12,56 +33,64 @@ public record Piece (Color color, Type type) implements Comparable<Piece> {
         return this.type;
     }
 
-    private static Piece createWhite(final Type type) { return new Piece(Color.WHITE, type); }
-    private static Piece createBlack(final Type type) { return new Piece(Color.BLACK, type); }
-
-    public static Piece createWhitePawn() {
-        return createWhite(Type.PAWN);
+    public Position getPosition() {
+        return this.position;
     }
 
-    public static Piece createBlackPawn() { return createBlack(Type.PAWN); }
+    private static Piece createWhite(final Type type, final Position position) { return new Piece(Color.WHITE, type, position); }
+    private static Piece createBlack(final Type type, final Position position) { return new Piece(Color.BLACK, type, position); }
 
-    public static Piece createWhiteKnight() {
-        return createWhite(Type.KNIGHT);
+    public static Piece createMovedPiece(final Piece piece, final Position position) {
+        return new Piece(piece.getColor(), piece.getType(), position);
     }
 
-    public static Piece createBlackKnight() {
-        return createBlack(Type.KNIGHT);
+    public static Piece createWhitePawn(final Position position) {
+        return createWhite(Type.PAWN, position);
     }
 
-    public static Piece createWhiteRook() {
-        return createWhite(Type.ROOK);
+    public static Piece createBlackPawn(final Position position) { return createBlack(Type.PAWN, position); }
+
+    public static Piece createWhiteKnight(final Position position) {
+        return createWhite(Type.KNIGHT, position);
     }
 
-    public static Piece createBlackRook() {
-        return createBlack(Type.ROOK);
+    public static Piece createBlackKnight(final Position position) {
+        return createBlack(Type.KNIGHT, position);
     }
 
-    public static Piece createWhiteBishop() {
-        return createWhite(Type.BISHOP);
+    public static Piece createWhiteRook(final Position position) {
+        return createWhite(Type.ROOK, position);
     }
 
-    public static Piece createBlackBishop() {
-        return createBlack(Type.BISHOP);
+    public static Piece createBlackRook(final Position position) {
+        return createBlack(Type.ROOK, position);
     }
 
-    public static Piece createWhiteQueen() {
-        return createWhite(Type.QUEEN);
+    public static Piece createWhiteBishop(final Position position) {
+        return createWhite(Type.BISHOP, position);
     }
 
-    public static Piece createBlackQueen() {
-        return createBlack(Type.QUEEN);
+    public static Piece createBlackBishop(final Position position) {
+        return createBlack(Type.BISHOP, position);
     }
 
-    public static Piece createWhiteKing() {
-        return createWhite(Type.KING);
+    public static Piece createWhiteQueen(final Position position) {
+        return createWhite(Type.QUEEN, position);
     }
 
-    public static Piece createBlackKing() {
-        return createBlack(Type.KING);
+    public static Piece createBlackQueen(final Position position) {
+        return createBlack(Type.QUEEN, position);
     }
 
-    public static Piece createBlank() { return new Piece(Color.NO_COLOR, Type.NO_PIECE); }
+    public static Piece createWhiteKing(final Position position) {
+        return createWhite(Type.KING, position);
+    }
+
+    public static Piece createBlackKing(final Position position) {
+        return createBlack(Type.KING, position);
+    }
+
+    public static Piece createBlank(final Position position) { return new Piece(Color.NO_COLOR, Type.NO_PIECE, position); }
 
     public boolean isWhite() { return Objects.equals(this.color, Color.WHITE); }
 
@@ -70,26 +99,5 @@ public record Piece (Color color, Type type) implements Comparable<Piece> {
     @Override
     public int compareTo(Piece piece) {
         return Double.compare(piece.getType().getDefaultPoint(), this.getType().getDefaultPoint());
-    }
-
-    // test를 위한 메서드
-    private static Type getTypeOfRepresentation(final char representation) {
-        char lowerRepresentation = Character.toLowerCase(representation);
-        return switch (lowerRepresentation) {
-            case 'p' -> Type.PAWN;
-            case 'r' -> Type.ROOK;
-            case 'n' -> Type.KNIGHT;
-            case 'b' -> Type.BISHOP;
-            case 'q' -> Type.QUEEN;
-            case 'k' -> Type.KING;
-            default -> Type.NO_PIECE;
-        };
-    }
-
-    // test를 위한 메서드
-    public static Piece create(final char representation) {
-        if (representation == '.') return createBlank();
-        if ('a' <= representation && representation <= 'z') return createWhite(getTypeOfRepresentation(representation));
-        return createBlack(getTypeOfRepresentation(representation));
     }
 }

--- a/src/main/java/chess/pieces/Piece.java
+++ b/src/main/java/chess/pieces/Piece.java
@@ -45,13 +45,12 @@ public abstract class Piece implements Comparable<Piece> {
     @Override
     public boolean equals(Object o) {
         if (Objects.equals(o, null)) return false;
+        if (this.getClass() != o.getClass()) return false;
 
         Piece piece = (Piece) o;
         if (!Objects.equals(this.color, piece.getColor())) return false;
         if (!Objects.equals(this.type, piece.getType())) return false;
-        if (!Objects.equals(this.position, piece.getPosition())) return false;
-
-        return true;
+        return Objects.equals(this.position, piece.getPosition());
     }
 
     public Color getColor() {

--- a/src/main/java/chess/pieces/Piece.java
+++ b/src/main/java/chess/pieces/Piece.java
@@ -1,17 +1,44 @@
 package chess.pieces;
 
+import chess.Position;
+import chess.constant.Color;
+import chess.constant.Direction;
+import chess.constant.Type;
+
+import java.util.List;
 import java.util.Objects;
 
-public class Piece implements Comparable<Piece> {
+public abstract class Piece implements Comparable<Piece> {
 
     private final Color color;
     private final Type type;
     private final Position position;
 
-    private Piece(final Color color, final Type type, final Position position) {
+    protected Piece(final Color color, final Type type, final Position position) {
         this.color = color;
         this.type = type;
         this.position = position;
+    }
+
+    public abstract boolean verifyMovePosition(final Position position);
+    public abstract Direction getDirection(final Position position);
+
+    public Direction getDirection(Position position, List<Direction> directions) {
+        Position sourcePosition = this.getPosition();
+
+        int distance = 64;
+        Direction result = null;
+        for (Direction direction: directions) {
+            int y = sourcePosition.getY() + direction.getYDegree();
+            int x = sourcePosition.getX() + direction.getXDegree();
+
+            int directionDistance = Math.abs(position.getX() - x) + Math.abs(position.getY() - y);
+            if (distance > directionDistance) {
+                distance = directionDistance;
+                result = direction;
+            }
+        }
+        return result;
     }
 
     @Override
@@ -21,6 +48,7 @@ public class Piece implements Comparable<Piece> {
         Piece piece = (Piece) o;
         if (!Objects.equals(this.color, piece.getColor())) return false;
         if (!Objects.equals(this.type, piece.getType())) return false;
+        if (!Objects.equals(this.position, piece.getPosition())) return false;
 
         return true;
     }
@@ -36,61 +64,6 @@ public class Piece implements Comparable<Piece> {
     public Position getPosition() {
         return this.position;
     }
-
-    private static Piece createWhite(final Type type, final Position position) { return new Piece(Color.WHITE, type, position); }
-    private static Piece createBlack(final Type type, final Position position) { return new Piece(Color.BLACK, type, position); }
-
-    public static Piece createMovedPiece(final Piece piece, final Position position) {
-        return new Piece(piece.getColor(), piece.getType(), position);
-    }
-
-    public static Piece createWhitePawn(final Position position) {
-        return createWhite(Type.PAWN, position);
-    }
-
-    public static Piece createBlackPawn(final Position position) { return createBlack(Type.PAWN, position); }
-
-    public static Piece createWhiteKnight(final Position position) {
-        return createWhite(Type.KNIGHT, position);
-    }
-
-    public static Piece createBlackKnight(final Position position) {
-        return createBlack(Type.KNIGHT, position);
-    }
-
-    public static Piece createWhiteRook(final Position position) {
-        return createWhite(Type.ROOK, position);
-    }
-
-    public static Piece createBlackRook(final Position position) {
-        return createBlack(Type.ROOK, position);
-    }
-
-    public static Piece createWhiteBishop(final Position position) {
-        return createWhite(Type.BISHOP, position);
-    }
-
-    public static Piece createBlackBishop(final Position position) {
-        return createBlack(Type.BISHOP, position);
-    }
-
-    public static Piece createWhiteQueen(final Position position) {
-        return createWhite(Type.QUEEN, position);
-    }
-
-    public static Piece createBlackQueen(final Position position) {
-        return createBlack(Type.QUEEN, position);
-    }
-
-    public static Piece createWhiteKing(final Position position) {
-        return createWhite(Type.KING, position);
-    }
-
-    public static Piece createBlackKing(final Position position) {
-        return createBlack(Type.KING, position);
-    }
-
-    public static Piece createBlank(final Position position) { return new Piece(Color.NO_COLOR, Type.NO_PIECE, position); }
 
     public boolean isWhite() { return Objects.equals(this.color, Color.WHITE); }
 

--- a/src/main/java/chess/pieces/Piece.java
+++ b/src/main/java/chess/pieces/Piece.java
@@ -1,5 +1,6 @@
 package chess.pieces;
 
+import chess.Board;
 import chess.Position;
 import chess.constant.Color;
 import chess.constant.Direction;
@@ -20,13 +21,13 @@ public abstract class Piece implements Comparable<Piece> {
         this.position = position;
     }
 
-    public abstract boolean verifyMovePosition(final Position position);
+    public abstract boolean verifyMovePosition(final Piece piece);
     public abstract Direction getDirection(final Position position);
 
     public Direction getDirection(Position position, List<Direction> directions) {
         Position sourcePosition = this.getPosition();
 
-        int distance = 64;
+        int distance = Board.BOARD_SIZE;
         Direction result = null;
         for (Direction direction: directions) {
             int y = sourcePosition.getY() + direction.getYDegree();

--- a/src/main/java/chess/pieces/PieceFactory.java
+++ b/src/main/java/chess/pieces/PieceFactory.java
@@ -1,0 +1,48 @@
+package chess.pieces;
+
+import chess.Position;
+import chess.constant.Color;
+import chess.constant.Type;
+
+public class PieceFactory {
+    public static Piece createMovedPiece(final Piece piece, final Position position) {
+        Piece result = null;
+        switch (piece.getType()) {
+            case Type.PAWN -> result = createPawn(piece.getColor(), position);
+            case Type.KNIGHT -> result = createKnight(piece.getColor(), position);
+            case Type.ROOK -> result = createRook(piece.getColor(), position);
+            case Type.BISHOP -> result = createBishop(piece.getColor(), position);
+            case Type.QUEEN -> result = createQueen(piece.getColor(), position);
+            case Type.KING -> result = createKing(piece.getColor(), position);
+            case Type.NO_PIECE -> result = createBlank(position);
+        }
+        return result;
+    }
+
+    public static Piece createPawn(final Color color, final Position position) {
+        return Pawn.create(color, position);
+    }
+
+    public static Piece createKnight(final Color color, final Position position) {
+        return Knight.create(color, position);
+    }
+
+    public static Piece createRook(final Color color, final Position position) {
+        return Rook.create(color, position);
+    }
+
+    public static Piece createBishop(final Color color, final Position position) {
+        return Bishop.create(color, position);
+    }
+
+    public static Piece createQueen(final Color color, final Position position) {
+        return Queen.create(color, position);
+    }
+
+    public static Piece createKing(final Color color, final Position position) {
+        return King.create(color, position);
+    }
+
+    public static Piece createBlank(final Position position) { return Blank.create(position); }
+
+}

--- a/src/main/java/chess/pieces/Position.java
+++ b/src/main/java/chess/pieces/Position.java
@@ -3,6 +3,11 @@ package chess.pieces;
 public class Position {
     private final int x, y;
 
+    public Position(final int x, final int y) {
+        this.x = x;
+        this.y = y;
+    }
+
     public Position(final String position) {
         this.x = position.charAt(0) - 'a';
         this.y = 8 - Character.getNumericValue(position.charAt(1));

--- a/src/main/java/chess/pieces/Position.java
+++ b/src/main/java/chess/pieces/Position.java
@@ -1,5 +1,7 @@
 package chess.pieces;
 
+import static chess.Board.BOARD_SIZE;
+
 public class Position {
     private final int x, y;
 
@@ -15,4 +17,7 @@ public class Position {
 
     public int getX() { return this.x; }
     public int getY() { return this.y; }
+    public boolean isOutOfIndex() {
+        return !((0 <= x && x < BOARD_SIZE) && (0 <= y && y < BOARD_SIZE));
+    }
 }

--- a/src/main/java/chess/pieces/Queen.java
+++ b/src/main/java/chess/pieces/Queen.java
@@ -1,0 +1,44 @@
+package chess.pieces;
+
+import chess.Position;
+import chess.constant.Color;
+import chess.constant.Direction;
+import chess.constant.Type;
+
+import java.util.List;
+
+public class Queen extends Piece {
+    private final List<Direction> directions = Direction.everyDirection();
+
+    private Queen(final Color color, final Position position) { super(color, Type.QUEEN, position); }
+
+    public static Piece create(Color color, Position position) {
+        return new Queen(color, position);
+    }
+
+    @Override
+    public boolean verifyMovePosition(final Piece piece) {
+        Position sourcePosition = this.getPosition();
+        Position destinationPosition = piece.getPosition();
+
+        for (Direction direction: directions) {
+            Position nextPosition = new Position(sourcePosition.getX() + direction.getXDegree(), sourcePosition.getY() + direction.getYDegree());
+            boolean moveAvailable = moveVirtualQueen(nextPosition, destinationPosition, direction.getYDegree(), direction.getXDegree());
+            if (moveAvailable) return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Direction getDirection(Position position) {
+        return getDirection(position, directions);
+    }
+
+    private boolean moveVirtualQueen(final Position source, final Position destination, final int y_grad, final int x_grad) {
+        if (source.isOutOfIndex()) return false;
+        if (source.getX() == destination.getX() && source.getY() == destination.getY()) return true;
+
+        Position position = new Position(source.getX() + x_grad, source.getY() + y_grad);
+        return moveVirtualQueen(position, destination, y_grad, x_grad);
+    }
+}

--- a/src/main/java/chess/pieces/Rank.java
+++ b/src/main/java/chess/pieces/Rank.java
@@ -1,5 +1,6 @@
 package chess.pieces;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -16,11 +17,6 @@ public class Rank {
         return (int) rank.stream().filter(piece -> !Objects.equals(piece.getType(), Type.NO_PIECE)).count();
     }
 
-    public int getCount(final Color color, final Type type) {
-        return (int) rank.stream().filter(
-                piece -> Objects.equals(color, piece.getColor()) && Objects.equals(type, piece.getType())).count();
-    }
-
     public String showRank() {
         StringBuilder stringBuilder = new StringBuilder();
         rank.forEach(piece -> {
@@ -31,7 +27,9 @@ public class Rank {
         return stringBuilder.toString();
     }
 
-    public void move(final int x, final Piece piece) {
-        rank.set(x, piece);
+    public Rank move(final int x, final Piece piece, final Position position) {
+        List<Piece> newRank = new ArrayList<>(rank);
+        newRank.set(x, Piece.createMovedPiece(piece, position));
+        return new Rank(newRank);
     }
 }

--- a/src/main/java/chess/pieces/Rook.java
+++ b/src/main/java/chess/pieces/Rook.java
@@ -1,0 +1,44 @@
+package chess.pieces;
+
+import chess.Position;
+import chess.constant.Color;
+import chess.constant.Direction;
+import chess.constant.Type;
+
+import java.util.List;
+
+public class Rook extends Piece {
+    private final List<Direction> directions = Direction.linearDirection();
+
+    private Rook(final Color color, final Position position) { super(color, Type.ROOK, position); }
+
+    public static Piece create(Color color, Position position) {
+        return new Rook(color, position);
+    }
+
+    @Override
+    public boolean verifyMovePosition(final Piece piece) {
+        Position sourcePosition = this.getPosition();
+        Position destinationPosition = piece.getPosition();
+
+        for (Direction direction: directions) {
+            Position nextPosition = new Position(sourcePosition.getX() + direction.getXDegree(), sourcePosition.getY() + direction.getYDegree());
+            boolean moveAvailable = moveVirtualRook(nextPosition, destinationPosition, direction.getYDegree(), direction.getXDegree());
+            if (moveAvailable) return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Direction getDirection(Position position) {
+        return getDirection(position, directions);
+    }
+
+    private boolean moveVirtualRook(final Position source, final Position destination, final int y_grad, final int x_grad) {
+        if (source.isOutOfIndex()) return false;
+        if (source.getX() == destination.getX() && source.getY() == destination.getY()) return true;
+
+        Position position = new Position(source.getX() + x_grad, source.getY() + y_grad);
+        return moveVirtualRook(position, destination, y_grad, x_grad);
+    }
+}

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -2,6 +2,7 @@ package chess;
 
 import chess.pieces.Color;
 import chess.pieces.Piece;
+import chess.pieces.Position;
 import chess.pieces.Type;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,17 +15,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BoardTest {
     private Board board;
+    private ChessView chessView;
+    private ChessGame chessGame;
 
     @BeforeEach
     public void setUp() {
         board = new Board();
+        chessView = new ChessView(board);
+        chessGame = new ChessGame(board);
     }
 
     @Test
     @DisplayName("보드에 폰을 추가할 수 있다")
     public void create() {
-        board.initialize();
-        assertEquals(32, board.pieceCount());
+        chessGame.start();
+        assertEquals(32, chessGame.pieceCount());
         String blankRank = appendNewLine("........");
         assertEquals(
                 appendNewLine("RNBQKBNR") +
@@ -32,89 +37,72 @@ public class BoardTest {
                         blankRank + blankRank + blankRank + blankRank +
                         appendNewLine("pppppppp") +
                         appendNewLine("rnbqkbnr"),
-                board.showBoard());
+                chessView.showBoard());
     }
 
     @Test
     @DisplayName("체스판을 출력할 수 있다")
     public void showBoard() {
-        board.initialize();
-        System.out.println(board.showBoard());
+        chessGame.start();
+        System.out.println(chessView.showBoard());
     }
 
     @Test
     @DisplayName("기물과 색에 해당하는 기물의 개수를 반환한다")
     public void countPieces() {
-        board.initialize();
-        assertEquals(8, board.countPieces(Color.BLACK, Type.PAWN));
-
-        board.updateBoard(List.of(
-                ".KR.....",
-                "P.PB....",
-                ".P..Q...",
-                "........",
-                ".....nq.",
-                ".....p..",
-                "......p.",
-                "....rk.."
-        ));
-        System.out.println(board.showBoard());
-        assertEquals(3, board.countPieces(Color.BLACK, Type.PAWN));
+        chessGame.start();
+        assertEquals(8, chessGame.countPieces(Color.BLACK, Type.PAWN));
     }
 
     @Test
     @DisplayName("주어진 위치의 기물을 조회할 수 있다")
     public void findPiece() {
-        board.initialize();
-
-        assertEquals(Piece.createBlackRook(), board.findPiece("a8"));
-        assertEquals(Piece.createBlackRook(), board.findPiece("h8"));
-        assertEquals(Piece.createWhiteRook(), board.findPiece("a1"));
-        assertEquals(Piece.createWhiteRook(), board.findPiece("h1"));
+        chessGame.start();
+        assertEquals(Piece.createBlackRook(new Position("a8")), board.findPiece("a8"));
+        assertEquals(Piece.createBlackRook(new Position("h8")), board.findPiece("h8"));
+        assertEquals(Piece.createWhiteRook(new Position("a1")), board.findPiece("a1"));
+        assertEquals(Piece.createWhiteRook(new Position("h1")), board.findPiece("h1"));
     }
 
     @Test
-    @DisplayName("임의의 기물을 체스판 위에 추가할 수 있다")
+    @DisplayName("임의의 기물을 체스판의 다른 위치로 이동할 수 있다")
     public void move() {
-        board.initializeEmpty();
-
-        String position = "b5";
-        Piece piece = Piece.createBlackRook();
-        board.move(position, piece);
-
-        assertEquals(piece, board.findPiece(position));
-        System.out.println(board.showBoard());
+        chessGame.start();
+        String sourcePosition = "b2";
+        String targetPosition = "b3";
+        chessGame.move(sourcePosition, targetPosition);
+        assertEquals(Piece.createBlank(new Position(sourcePosition)), board.findPiece(sourcePosition));
+        assertEquals(Piece.createWhitePawn(new Position(targetPosition)), board.findPiece(targetPosition));
     }
 
     @Test
     @DisplayName("남아있는 기물에 대한 점수 계산이 가능해야한다")
     public void caculcatePoint() {
-        board.initializeEmpty();
+        board.initialize();
+        addPiece("b6", Piece.createBlackPawn(new Position("b6")));
+        addPiece("e6", Piece.createBlackQueen(new Position("e6")));
+        addPiece("b8", Piece.createBlackKing(new Position("b8")));
+        addPiece("c8", Piece.createBlackRook(new Position("c8")));
 
-        addPiece("b6", Piece.createBlackPawn());
-        addPiece("e6", Piece.createBlackQueen());
-        addPiece("b8", Piece.createBlackKing());
-        addPiece("c8", Piece.createBlackRook());
+        addPiece("f2", Piece.createWhitePawn(new Position("f2")));
+        addPiece("g2", Piece.createWhitePawn(new Position("g2")));
+        addPiece("e1", Piece.createWhiteRook(new Position("e1")));
+        addPiece("f1", Piece.createWhiteKing(new Position("f1")));
 
-        addPiece("f2", Piece.createWhitePawn());
-        addPiece("g2", Piece.createWhitePawn());
-        addPiece("e1", Piece.createWhiteRook());
-        addPiece("f1", Piece.createWhiteKing());
+        assertEquals(15.0, chessGame.calculatePoint(Color.BLACK), 0.01);
+        assertEquals(7.0, chessGame.calculatePoint(Color.WHITE), 0.01);
 
-        assertEquals(15.0, board.calculatePoint(Color.BLACK), 0.01);
-        assertEquals(7.0, board.calculatePoint(Color.WHITE), 0.01);
-
-        System.out.println(board.showBoard());
+        System.out.println(chessView.showBoard());
     }
 
     private void addPiece(final String position, final Piece piece) {
-        board.move(position, piece);
+        chessGame.move(position, piece);
     }
 
     @Test
     @DisplayName("원하는 색상의 기물들을 정렬된 리스트로 받을 수 있어야 한다")
     public void getSortedPieces() {
-        board.initialize();
+        chessGame.start();
         List<Piece> sortedWhitePieces = board.getSortedPieces(Color.WHITE);
         System.out.println(sortedWhitePieces);
         System.out.println(sortedWhitePieces.reversed());

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -124,4 +124,18 @@ public class BoardTest {
         chessGame.move("b8", "b7");
         assertEquals(Piece.createBlackKing(new Position("b7")), board.findPiece("b7"));
     }
+
+    @Test
+    @DisplayName("Queen 기물이 원하는 대로 이동이 가능해야 한다")
+    public void moveQueen() {
+        board.initialize();
+        board.saveByPosition(Piece.createBlackQueen(null), new Position(1, 0));
+
+        chessGame.move("b8", "a8");
+        assertEquals(Piece.createBlackQueen(new Position("a8")), board.findPiece("a8"));
+
+        chessGame.move("a8", "e4");
+        assertEquals(Piece.createBlackQueen(new Position("e4")), board.findPiece("e4"));
+    }
+
 }

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -108,34 +108,4 @@ public class BoardTest {
         System.out.println(sortedWhitePieces.reversed());
     }
 
-    @Test
-    @DisplayName("King 기물이 원하는 대로 이동이 가능해야 한다")
-    public void moveKing() {
-        board.initialize();
-        board.saveByPosition(PieceFactory.createKing(Color.BLACK, null), new Position(1, 0));
-        board.saveByPosition(PieceFactory.createKnight(Color.BLACK, null), new Position(0, 0));
-
-        chessGame.move("b8", "a8");
-        assertEquals(PieceFactory.createKing(Color.BLACK, new Position("b8")), board.findPiece("b8"));
-
-        chessGame.move("b8", "b9");
-        assertEquals(PieceFactory.createKing(Color.BLACK, new Position("b8")), board.findPiece("b8"));
-
-        chessGame.move("b8", "b7");
-        assertEquals(PieceFactory.createKing(Color.BLACK, new Position("b7")), board.findPiece("b7"));
-    }
-
-    @Test
-    @DisplayName("Queen 기물이 원하는 대로 이동이 가능해야 한다")
-    public void moveQueen() {
-        board.initialize();
-        board.saveByPosition(PieceFactory.createQueen(Color.BLACK, null), new Position(1, 0));
-
-        chessGame.move("b8", "a8");
-        assertEquals(PieceFactory.createQueen(Color.BLACK, new Position("a8")), board.findPiece("a8"));
-
-        chessGame.move("a8", "e4");
-        assertEquals(PieceFactory.createQueen(Color.BLACK, new Position("e4")), board.findPiece("e4"));
-    }
-
 }

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -1,9 +1,9 @@
 package chess;
 
-import chess.pieces.Color;
+import chess.constant.Color;
 import chess.pieces.Piece;
-import chess.pieces.Position;
-import chess.pieces.Type;
+import chess.constant.Type;
+import chess.pieces.PieceFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -58,10 +58,10 @@ public class BoardTest {
     @DisplayName("주어진 위치의 기물을 조회할 수 있다")
     public void findPiece() {
         chessGame.start();
-        assertEquals(Piece.createBlackRook(new Position("a8")), board.findPiece("a8"));
-        assertEquals(Piece.createBlackRook(new Position("h8")), board.findPiece("h8"));
-        assertEquals(Piece.createWhiteRook(new Position("a1")), board.findPiece("a1"));
-        assertEquals(Piece.createWhiteRook(new Position("h1")), board.findPiece("h1"));
+        assertEquals(PieceFactory.createRook(Color.BLACK, new Position("a8")), board.findPiece("a8"));
+        assertEquals(PieceFactory.createRook(Color.BLACK, new Position("h8")), board.findPiece("h8"));
+        assertEquals(PieceFactory.createRook(Color.WHITE, new Position("a1")), board.findPiece("a1"));
+        assertEquals(PieceFactory.createRook(Color.WHITE, new Position("h1")), board.findPiece("h1"));
     }
 
     @Test
@@ -71,23 +71,23 @@ public class BoardTest {
         String sourcePosition = "b2";
         String targetPosition = "b3";
         chessGame.move(sourcePosition, targetPosition);
-        assertEquals(Piece.createBlank(new Position(sourcePosition)), board.findPiece(sourcePosition));
-        assertEquals(Piece.createWhitePawn(new Position(targetPosition)), board.findPiece(targetPosition));
+        //assertEquals(Piece.createBlank(new Position(sourcePosition)), board.findPiece(sourcePosition));
+        //assertEquals(Piece.createWhitePawn(new Position(targetPosition)), board.findPiece(targetPosition));
     }
 
     @Test
     @DisplayName("남아있는 기물에 대한 점수 계산이 가능해야한다")
     public void caculcatePoint() {
         board.initialize();
-        addPiece("b6", Piece.createBlackPawn(new Position("b6")));
-        addPiece("e6", Piece.createBlackQueen(new Position("e6")));
-        addPiece("b8", Piece.createBlackKing(new Position("b8")));
-        addPiece("c8", Piece.createBlackRook(new Position("c8")));
+        addPiece("b6", PieceFactory.createPawn(Color.BLACK, new Position("b6")));
+        addPiece("e6", PieceFactory.createQueen(Color.BLACK, new Position("e6")));
+        addPiece("b8", PieceFactory.createKing(Color.BLACK, new Position("b8")));
+        addPiece("c8", PieceFactory.createRook(Color.BLACK, new Position("c8")));
 
-        addPiece("f2", Piece.createWhitePawn(new Position("f2")));
-        addPiece("g2", Piece.createWhitePawn(new Position("g2")));
-        addPiece("e1", Piece.createWhiteRook(new Position("e1")));
-        addPiece("f1", Piece.createWhiteKing(new Position("f1")));
+        addPiece("f2", PieceFactory.createPawn(Color.WHITE, new Position("f2")));
+        addPiece("g2", PieceFactory.createPawn(Color.WHITE, new Position("g2")));
+        addPiece("e1", PieceFactory.createRook(Color.WHITE, new Position("e1")));
+        addPiece("f1", PieceFactory.createKing(Color.WHITE, new Position("f1")));
 
         assertEquals(15.0, chessGame.calculatePoint(Color.BLACK), 0.01);
         assertEquals(7.0, chessGame.calculatePoint(Color.WHITE), 0.01);
@@ -112,30 +112,30 @@ public class BoardTest {
     @DisplayName("King 기물이 원하는 대로 이동이 가능해야 한다")
     public void moveKing() {
         board.initialize();
-        board.saveByPosition(Piece.createBlackKing(null), new Position(1, 0));
-        board.saveByPosition(Piece.createBlackKnight(null), new Position(0, 0));
+        board.saveByPosition(PieceFactory.createKing(Color.BLACK, null), new Position(1, 0));
+        board.saveByPosition(PieceFactory.createKnight(Color.BLACK, null), new Position(0, 0));
 
         chessGame.move("b8", "a8");
-        assertEquals(Piece.createBlackKing(new Position("b8")), board.findPiece("b8"));
+        assertEquals(PieceFactory.createKing(Color.BLACK, new Position("b8")), board.findPiece("b8"));
 
         chessGame.move("b8", "b9");
-        assertEquals(Piece.createBlackKing(new Position("b8")), board.findPiece("b8"));
+        assertEquals(PieceFactory.createKing(Color.BLACK, new Position("b8")), board.findPiece("b8"));
 
         chessGame.move("b8", "b7");
-        assertEquals(Piece.createBlackKing(new Position("b7")), board.findPiece("b7"));
+        assertEquals(PieceFactory.createKing(Color.BLACK, new Position("b7")), board.findPiece("b7"));
     }
 
     @Test
     @DisplayName("Queen 기물이 원하는 대로 이동이 가능해야 한다")
     public void moveQueen() {
         board.initialize();
-        board.saveByPosition(Piece.createBlackQueen(null), new Position(1, 0));
+        board.saveByPosition(PieceFactory.createQueen(Color.BLACK, null), new Position(1, 0));
 
         chessGame.move("b8", "a8");
-        assertEquals(Piece.createBlackQueen(new Position("a8")), board.findPiece("a8"));
+        assertEquals(PieceFactory.createQueen(Color.BLACK, new Position("a8")), board.findPiece("a8"));
 
         chessGame.move("a8", "e4");
-        assertEquals(Piece.createBlackQueen(new Position("e4")), board.findPiece("e4"));
+        assertEquals(PieceFactory.createQueen(Color.BLACK, new Position("e4")), board.findPiece("e4"));
     }
 
 }

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -107,4 +107,21 @@ public class BoardTest {
         System.out.println(sortedWhitePieces);
         System.out.println(sortedWhitePieces.reversed());
     }
+
+    @Test
+    @DisplayName("King 기물이 원하는 대로 이동이 가능해야 한다")
+    public void moveKing() {
+        board.initialize();
+        board.saveByPosition(Piece.createBlackKing(null), new Position(1, 0));
+        board.saveByPosition(Piece.createBlackKnight(null), new Position(0, 0));
+
+        chessGame.move("b8", "a8");
+        assertEquals(Piece.createBlackKing(new Position("b8")), board.findPiece("b8"));
+
+        chessGame.move("b8", "b9");
+        assertEquals(Piece.createBlackKing(new Position("b8")), board.findPiece("b8"));
+
+        chessGame.move("b8", "b7");
+        assertEquals(Piece.createBlackKing(new Position("b7")), board.findPiece("b7"));
+    }
 }

--- a/src/test/java/chess/pieces/BishopTest.java
+++ b/src/test/java/chess/pieces/BishopTest.java
@@ -1,0 +1,46 @@
+package chess.pieces;
+
+import chess.Board;
+import chess.ChessGame;
+import chess.ChessView;
+import chess.Position;
+import chess.constant.Color;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BishopTest {
+    private Board board;
+    private ChessView chessView;
+    private ChessGame chessGame;
+
+    @BeforeEach
+    public void setUp() {
+        board = new Board();
+        chessView = new ChessView(board);
+        chessGame = new ChessGame(board);
+    }
+
+    @Test
+    @DisplayName("Bishop 기물이 원하는 대로 이동이 가능해야 한다")
+    public void moveBishop() {
+        board.initialize();
+        board.saveByPosition(PieceFactory.createBishop(Color.BLACK, null), new Position(1, 0));
+        board.saveByPosition(PieceFactory.createBishop(Color.WHITE, null), new Position(0, 1));
+        board.saveByPosition(PieceFactory.createBishop(Color.BLACK, null), new Position(2, 1));
+
+        chessGame.move("b8", "d6");
+        System.out.println(chessView.showBoard());
+        assertEquals(PieceFactory.createBishop(Color.BLACK, new Position("b8")), board.findPiece("b8"));
+
+        chessGame.move("b8", "c7");
+        System.out.println(chessView.showBoard());
+        assertEquals(PieceFactory.createBishop(Color.BLACK, new Position("b8")), board.findPiece("b8"));
+
+        chessGame.move("b8", "a7");
+        System.out.println(chessView.showBoard());
+        assertEquals(PieceFactory.createBishop(Color.BLACK, new Position("a7")), board.findPiece("a7"));
+    }
+}

--- a/src/test/java/chess/pieces/KingTest.java
+++ b/src/test/java/chess/pieces/KingTest.java
@@ -1,0 +1,42 @@
+package chess.pieces;
+
+import chess.Board;
+import chess.ChessGame;
+import chess.ChessView;
+import chess.Position;
+import chess.constant.Color;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KingTest {
+    private Board board;
+    private ChessView chessView;
+    private ChessGame chessGame;
+
+    @BeforeEach
+    public void setUp() {
+        board = new Board();
+        chessView = new ChessView(board);
+        chessGame = new ChessGame(board);
+    }
+
+    @Test
+    @DisplayName("King 기물이 원하는 대로 이동이 가능해야 한다")
+    public void moveKing() {
+        board.initialize();
+        board.saveByPosition(PieceFactory.createKing(Color.BLACK, null), new Position(1, 0));
+        board.saveByPosition(PieceFactory.createKnight(Color.BLACK, null), new Position(0, 0));
+
+        chessGame.move("b8", "a8");
+        assertEquals(PieceFactory.createKing(Color.BLACK, new Position("b8")), board.findPiece("b8"));
+
+        chessGame.move("b8", "b9");
+        assertEquals(PieceFactory.createKing(Color.BLACK, new Position("b8")), board.findPiece("b8"));
+
+        chessGame.move("b8", "b7");
+        assertEquals(PieceFactory.createKing(Color.BLACK, new Position("b7")), board.findPiece("b7"));
+    }
+}

--- a/src/test/java/chess/pieces/KingTest.java
+++ b/src/test/java/chess/pieces/KingTest.java
@@ -31,12 +31,15 @@ public class KingTest {
         board.saveByPosition(PieceFactory.createKnight(Color.BLACK, null), new Position(0, 0));
 
         chessGame.move("b8", "a8");
+        System.out.println(chessView.showBoard());
         assertEquals(PieceFactory.createKing(Color.BLACK, new Position("b8")), board.findPiece("b8"));
 
         chessGame.move("b8", "b9");
+        System.out.println(chessView.showBoard());
         assertEquals(PieceFactory.createKing(Color.BLACK, new Position("b8")), board.findPiece("b8"));
 
         chessGame.move("b8", "b7");
+        System.out.println(chessView.showBoard());
         assertEquals(PieceFactory.createKing(Color.BLACK, new Position("b7")), board.findPiece("b7"));
     }
 }

--- a/src/test/java/chess/pieces/KnightTest.java
+++ b/src/test/java/chess/pieces/KnightTest.java
@@ -1,0 +1,62 @@
+package chess.pieces;
+
+import chess.Board;
+import chess.ChessGame;
+import chess.ChessView;
+import chess.Position;
+import chess.constant.Color;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KnightTest {
+    private Board board;
+    private ChessView chessView;
+    private ChessGame chessGame;
+
+    @BeforeEach
+    public void setUp() {
+        board = new Board();
+        chessView = new ChessView(board);
+        chessGame = new ChessGame(board);
+    }
+
+    @Test
+    @DisplayName("Knight 기물이 원하는 대로 이동이 가능해야 한다")
+    public void moveKnight() {
+        board.initialize();
+        board.saveByPosition(PieceFactory.createKnight(Color.BLACK, null), new Position(1, 0));
+        board.saveByPosition(PieceFactory.createKnight(Color.WHITE, null), new Position(1, 4));
+        board.saveByPosition(PieceFactory.createKnight(Color.BLACK, null), new Position(3, 4));
+
+        chessGame.move("b8", "a8");
+        System.out.println(chessView.showBoard());
+        assertEquals(PieceFactory.createKnight(Color.BLACK, new Position("b8")), board.findPiece("b8"));
+
+        chessGame.move("b8", "c6");
+        System.out.println(chessView.showBoard());
+        assertEquals(PieceFactory.createKnight(Color.BLACK, new Position("c6")), board.findPiece("c6"));
+
+        chessGame.move("c6", "d4");
+        System.out.println(chessView.showBoard());
+        assertEquals(PieceFactory.createKnight(Color.BLACK, new Position("c6")), board.findPiece("c6"));
+
+        chessGame.move("c6", "b4");
+        System.out.println(chessView.showBoard());
+        assertEquals(PieceFactory.createKnight(Color.BLACK, new Position("b4")), board.findPiece("b4"));
+    }
+
+    @Test
+    @DisplayName("Knight 기물은 중간의 다른 기물을 뛰어 넘을 수 있어야 한다")
+    public void jumpKnight() {
+        board.initialize();
+        board.saveByPosition(PieceFactory.createKnight(Color.BLACK, null), new Position(1, 0));
+        board.saveByPosition(PieceFactory.createKnight(Color.WHITE, null), new Position(1, 1));
+
+        chessGame.move("b8", "c6");
+        System.out.println(chessView.showBoard());
+        assertEquals(PieceFactory.createKnight(Color.BLACK, new Position("c6")), board.findPiece("c6"));
+    }
+}

--- a/src/test/java/chess/pieces/PawnTest.java
+++ b/src/test/java/chess/pieces/PawnTest.java
@@ -1,0 +1,57 @@
+package chess.pieces;
+
+import chess.Board;
+import chess.ChessGame;
+import chess.ChessView;
+import chess.Position;
+import chess.constant.Color;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PawnTest {
+    private Board board;
+    private ChessView chessView;
+    private ChessGame chessGame;
+
+    @BeforeEach
+    public void setUp() {
+        board = new Board();
+        chessView = new ChessView(board);
+        chessGame = new ChessGame(board);
+    }
+
+    @Test
+    @DisplayName("Pawn 기물이 처음 이동 시 2칸 이동이 가능해야 한다")
+    public void movePawnFirst() {
+        board.initialize();
+        board.saveByPosition(PieceFactory.createPawn(Color.BLACK, null), new Position(1, 1));
+
+        chessGame.move("b7", "b5");
+        System.out.println(chessView.showBoard());
+        assertEquals(PieceFactory.createPawn(Color.BLACK, new Position("b5")), board.findPiece("b5"));
+
+        chessGame.move("b5", "b3");
+        System.out.println(chessView.showBoard());
+        assertEquals(PieceFactory.createPawn(Color.BLACK, new Position("b5")), board.findPiece("b5"));
+    }
+
+    @Test
+    @DisplayName("Pawn 기물이 원하는 대로 이동이 가능해야 한다")
+    public void movePawn() {
+        board.initialize();
+        board.saveByPosition(PieceFactory.createPawn(Color.BLACK, null), new Position(1, 1));
+        board.saveByPosition(PieceFactory.createPawn(Color.WHITE, null), new Position(2, 2));
+        board.saveByPosition(PieceFactory.createPawn(Color.WHITE, null), new Position(1, 3));
+
+        chessGame.move("b7", "b5");
+        System.out.println(chessView.showBoard());
+        assertEquals(PieceFactory.createPawn(Color.BLACK, new Position("b7")), board.findPiece("b7"));
+
+        chessGame.move("b7", "c6");
+        System.out.println(chessView.showBoard());
+        assertEquals(PieceFactory.createPawn(Color.BLACK, new Position("c6")), board.findPiece("c6"));
+    }
+}

--- a/src/test/java/chess/pieces/PieceTest.java
+++ b/src/test/java/chess/pieces/PieceTest.java
@@ -9,18 +9,18 @@ public class PieceTest {
     @Test
     @DisplayName("원하는 색상과 종류의 말이 생성되어야 한다")
     public void create_piece() {
-        verifyPiece(Piece.createWhitePawn(), Piece.createBlackPawn(), Type.PAWN);
-        verifyPiece(Piece.createWhiteKnight(), Piece.createBlackKnight(), Type.KNIGHT);
-        verifyPiece(Piece.createWhiteRook(), Piece.createBlackRook(), Type.ROOK);
-        verifyPiece(Piece.createWhiteBishop(), Piece.createBlackBishop(), Type.BISHOP);
-        verifyPiece(Piece.createWhiteQueen(), Piece.createBlackQueen(), Type.QUEEN);
-        verifyPiece(Piece.createWhiteKing(), Piece.createBlackKing(), Type.KING);
+        verifyPiece(Piece.createWhitePawn(new Position("a1")), Piece.createBlackPawn(new Position("a1")), Type.PAWN);
+        verifyPiece(Piece.createWhiteKnight(new Position("a1")), Piece.createBlackKnight(new Position("a1")), Type.KNIGHT);
+        verifyPiece(Piece.createWhiteRook(new Position("a1")), Piece.createBlackRook(new Position("a1")), Type.ROOK);
+        verifyPiece(Piece.createWhiteBishop(new Position("a1")), Piece.createBlackBishop(new Position("a1")), Type.BISHOP);
+        verifyPiece(Piece.createWhiteQueen(new Position("a1")), Piece.createBlackQueen(new Position("a1")), Type.QUEEN);
+        verifyPiece(Piece.createWhiteKing(new Position("a1")), Piece.createBlackKing(new Position("a1")), Type.KING);
 
-        Piece blank = Piece.createBlank();
+        Piece blank = Piece.createBlank(new Position("a1"));
         assertFalse(blank.isWhite());
         assertFalse(blank.isBlack());
         assertEquals(Type.NO_PIECE, blank.getType());
-        }
+    }
 
     private void verifyPiece(final Piece whitePiece, final Piece blackPiece, final Type type) {
         assertTrue(whitePiece.isWhite());
@@ -28,18 +28,6 @@ public class PieceTest {
 
         assertTrue(blackPiece.isBlack());
         assertEquals(type, blackPiece.getType());
-    }
-
-    @Test
-    @DisplayName("검정색과 하얀색을 구분할 수 있어야 한다")
-    public void isColor() {
-        Piece white = Piece.createWhitePawn();
-        assertTrue(white.isWhite());
-        assertFalse(white.isBlack());
-
-        Piece black = Piece.createBlackPawn();
-        assertFalse(black.isWhite());
-        assertTrue(black.isBlack());
     }
 
     @Test

--- a/src/test/java/chess/pieces/PieceTest.java
+++ b/src/test/java/chess/pieces/PieceTest.java
@@ -1,5 +1,7 @@
 package chess.pieces;
 
+import chess.Position;
+import chess.constant.Type;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
 

--- a/src/test/java/chess/pieces/PieceTest.java
+++ b/src/test/java/chess/pieces/PieceTest.java
@@ -1,6 +1,7 @@
 package chess.pieces;
 
 import chess.Position;
+import chess.constant.Color;
 import chess.constant.Type;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
@@ -11,14 +12,14 @@ public class PieceTest {
     @Test
     @DisplayName("원하는 색상과 종류의 말이 생성되어야 한다")
     public void create_piece() {
-        verifyPiece(Piece.createWhitePawn(new Position("a1")), Piece.createBlackPawn(new Position("a1")), Type.PAWN);
-        verifyPiece(Piece.createWhiteKnight(new Position("a1")), Piece.createBlackKnight(new Position("a1")), Type.KNIGHT);
-        verifyPiece(Piece.createWhiteRook(new Position("a1")), Piece.createBlackRook(new Position("a1")), Type.ROOK);
-        verifyPiece(Piece.createWhiteBishop(new Position("a1")), Piece.createBlackBishop(new Position("a1")), Type.BISHOP);
-        verifyPiece(Piece.createWhiteQueen(new Position("a1")), Piece.createBlackQueen(new Position("a1")), Type.QUEEN);
-        verifyPiece(Piece.createWhiteKing(new Position("a1")), Piece.createBlackKing(new Position("a1")), Type.KING);
+        verifyPiece(PieceFactory.createPawn(Color.WHITE, new Position("a1")), PieceFactory.createPawn(Color.BLACK, new Position("a1")), Type.PAWN);
+        verifyPiece(PieceFactory.createKnight(Color.WHITE, new Position("a1")), PieceFactory.createKnight(Color.BLACK, new Position("a1")), Type.KNIGHT);
+        verifyPiece(PieceFactory.createRook(Color.WHITE, new Position("a1")), PieceFactory.createRook(Color.BLACK, new Position("a1")), Type.ROOK);
+        verifyPiece(PieceFactory.createBishop(Color.WHITE, new Position("a1")), PieceFactory.createBishop(Color.BLACK, new Position("a1")), Type.BISHOP);
+        verifyPiece(PieceFactory.createQueen(Color.WHITE, new Position("a1")), PieceFactory.createQueen(Color.BLACK, new Position("a1")), Type.QUEEN);
+        verifyPiece(PieceFactory.createKing(Color.WHITE, new Position("a1")), PieceFactory.createKing(Color.BLACK, new Position("a1")), Type.KING);
 
-        Piece blank = Piece.createBlank(new Position("a1"));
+        Piece blank = PieceFactory.createBlank(new Position("a1"));
         assertFalse(blank.isWhite());
         assertFalse(blank.isBlack());
         assertEquals(Type.NO_PIECE, blank.getType());

--- a/src/test/java/chess/pieces/QueenTest.java
+++ b/src/test/java/chess/pieces/QueenTest.java
@@ -30,9 +30,11 @@ public class QueenTest {
         board.saveByPosition(PieceFactory.createQueen(Color.BLACK, null), new Position(1, 0));
 
         chessGame.move("b8", "a8");
+        System.out.println(chessView.showBoard());
         assertEquals(PieceFactory.createQueen(Color.BLACK, new Position("a8")), board.findPiece("a8"));
 
         chessGame.move("a8", "e4");
+        System.out.println(chessView.showBoard());
         assertEquals(PieceFactory.createQueen(Color.BLACK, new Position("e4")), board.findPiece("e4"));
     }
 }

--- a/src/test/java/chess/pieces/QueenTest.java
+++ b/src/test/java/chess/pieces/QueenTest.java
@@ -1,0 +1,38 @@
+package chess.pieces;
+
+import chess.Board;
+import chess.ChessGame;
+import chess.ChessView;
+import chess.Position;
+import chess.constant.Color;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class QueenTest {
+    private Board board;
+    private ChessView chessView;
+    private ChessGame chessGame;
+
+    @BeforeEach
+    public void setUp() {
+        board = new Board();
+        chessView = new ChessView(board);
+        chessGame = new ChessGame(board);
+    }
+
+    @Test
+    @DisplayName("Queen 기물이 원하는 대로 이동이 가능해야 한다")
+    public void moveQueen() {
+        board.initialize();
+        board.saveByPosition(PieceFactory.createQueen(Color.BLACK, null), new Position(1, 0));
+
+        chessGame.move("b8", "a8");
+        assertEquals(PieceFactory.createQueen(Color.BLACK, new Position("a8")), board.findPiece("a8"));
+
+        chessGame.move("a8", "e4");
+        assertEquals(PieceFactory.createQueen(Color.BLACK, new Position("e4")), board.findPiece("e4"));
+    }
+}

--- a/src/test/java/chess/pieces/RookTest.java
+++ b/src/test/java/chess/pieces/RookTest.java
@@ -1,0 +1,42 @@
+package chess.pieces;
+
+import chess.Board;
+import chess.ChessGame;
+import chess.ChessView;
+import chess.Position;
+import chess.constant.Color;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RookTest {
+    private Board board;
+    private ChessView chessView;
+    private ChessGame chessGame;
+
+    @BeforeEach
+    public void setUp() {
+        board = new Board();
+        chessView = new ChessView(board);
+        chessGame = new ChessGame(board);
+    }
+
+    @Test
+    @DisplayName("Rook 기물이 원하는 대로 이동이 가능해야 한다")
+    public void moveRook() {
+        board.initialize();
+        board.saveByPosition(PieceFactory.createRook(Color.BLACK, null), new Position(1, 0));
+        board.saveByPosition(PieceFactory.createRook(Color.WHITE, null), new Position(7, 0));
+        board.saveByPosition(PieceFactory.createRook(Color.BLACK, null), new Position(0, 0));
+
+        chessGame.move("b8", "a8");
+        System.out.println(chessView.showBoard());
+        assertEquals(PieceFactory.createRook(Color.BLACK, new Position("b8")), board.findPiece("b8"));
+
+        chessGame.move("b8", "h8");
+        System.out.println(chessView.showBoard());
+        assertEquals(PieceFactory.createRook(Color.BLACK, new Position("h8")), board.findPiece("h8"));
+    }
+}


### PR DESCRIPTION
## 구현 내용
- board의 역할을 분배하여 board, chess game, chess view로 변경
- 모든 기물들이 piece를 상속받도록 변경 및 팩토리 클래스 구현
- direction enum을 통한 모든 기물 규칙에 맞게 움직이도록 구현

## 고민 사항
- Q: board의 역할을 어떻게 나누는 것이 가장 좋을까?
   A: board는 해당 판의 상태, chess game은 게임 서비스 로직, chess view는 출력 로직만을 담도록 했다.

## 기타
